### PR TITLE
chore: Use the published NPM package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,8 +7,9 @@
     "": {
       "name": "extism-playground",
       "version": "0.1.0",
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "@extism/runtime-browser": "file:../extism-upstream/browser",
+        "@extism/runtime-browser": "^0.0.1-rc.6",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
@@ -24,6 +25,23 @@
       }
     },
     "../extism-upstream/browser": {
+      "version": "0.0.1-rc.6",
+      "extraneous": true,
+      "license": "BSD-3-Clause",
+      "devDependencies": {
+        "@types/jest": "^29.2.2",
+        "esbuild": "^0.15.13",
+        "jest": "^29.2.2",
+        "npm-dts": "^1.3.12",
+        "prettier": "^2.7.1",
+        "ts-jest": "^29.0.3",
+        "tslint": "^6.1.3",
+        "tslint-config-prettier": "^1.18.0",
+        "typescript": "^4.8.4"
+      }
+    },
+    "../extism/browser": {
+      "name": "@extism/runtime-browser",
       "version": "0.0.1-rc.6",
       "license": "BSD-3-Clause",
       "devDependencies": {
@@ -2217,7 +2235,7 @@
       }
     },
     "node_modules/@extism/runtime-browser": {
-      "resolved": "../extism-upstream/browser",
+      "resolved": "../extism/browser",
       "link": true
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -18180,7 +18198,7 @@
       }
     },
     "@extism/runtime-browser": {
-      "version": "file:../extism-upstream/browser",
+      "version": "file:../extism/browser",
       "requires": {
         "@types/jest": "^29.2.2",
         "esbuild": "^0.15.13",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "license": "BSD-3-Clause",
   "dependencies": {
-    "@extism/runtime-browser": "file:../extism-upstream/browser",
+    "@extism/runtime-browser": "^0.0.1-rc.6",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",


### PR DESCRIPTION
After mergeing, `npm install` to pull the library down. We may need to upgrade this a few times but this should make it easier for all of us to develop on.