### PR TITLE
feat: Use meta+enter instead of shift+enter

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -61,9 +61,8 @@ const App: React.FC = () => {
     }
   };
 
-  const onInputKeyPress = (e: Event) => {
-    //@ts-ignore
-    if (e.keyCode === 13 && e.shiftKey === true) {
+  const onInputKeyPress = (e: KeyboardEvent) => {
+    if (e.keyCode === 13 && e.metaKey) {
       e.preventDefault();
       handleOnRun(e);
     }


### PR DESCRIPTION
Instead of shift+enter we should probably use meta+enter. On mac meta is (command). Also wanted to test out cloudflare pages integration on this PR.