### PR TITLE
chore: upgrade to latest extism runtime version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@extism/runtime-browser": "0.0.1-rc.10",
+        "@extism/runtime-browser": "0.0.1-rc.13",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
@@ -2231,9 +2231,9 @@
       }
     },
     "node_modules/@extism/runtime-browser": {
-      "version": "0.0.1-rc.10",
-      "resolved": "https://registry.npmjs.org/@extism/runtime-browser/-/runtime-browser-0.0.1-rc.10.tgz",
-      "integrity": "sha512-Iv12f+vM48b7nbRaX4mjbIE+4jnSSC1MIsS5mpfIehfgRmWxCW6C1IRCilUuL9ppAdSy/ljs0nCwMvL0G1ToSQ=="
+      "version": "0.0.1-rc.13",
+      "resolved": "https://registry.npmjs.org/@extism/runtime-browser/-/runtime-browser-0.0.1-rc.13.tgz",
+      "integrity": "sha512-HJCh10rn8DgGb0AusA4JOvdcjah25SvNqtcMeabzRmkghzC7uslfPU5v6C027QR440NdJxVbCa1fovSnXqtTKQ=="
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.7",
@@ -18680,9 +18680,9 @@
       }
     },
     "@extism/runtime-browser": {
-      "version": "0.0.1-rc.10",
-      "resolved": "https://registry.npmjs.org/@extism/runtime-browser/-/runtime-browser-0.0.1-rc.10.tgz",
-      "integrity": "sha512-Iv12f+vM48b7nbRaX4mjbIE+4jnSSC1MIsS5mpfIehfgRmWxCW6C1IRCilUuL9ppAdSy/ljs0nCwMvL0G1ToSQ=="
+      "version": "0.0.1-rc.13",
+      "resolved": "https://registry.npmjs.org/@extism/runtime-browser/-/runtime-browser-0.0.1-rc.13.tgz",
+      "integrity": "sha512-HJCh10rn8DgGb0AusA4JOvdcjah25SvNqtcMeabzRmkghzC7uslfPU5v6C027QR440NdJxVbCa1fovSnXqtTKQ=="
     },
     "@humanwhocodes/config-array": {
       "version": "0.11.7",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "license": "BSD-3-Clause",
   "dependencies": {
-    "@extism/runtime-browser": "0.0.1-rc.10",
+    "@extism/runtime-browser": "0.0.1-rc.13",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -129,8 +129,8 @@ const App: React.FC = () => {
   const loadFunctions = async (manifest: any) => {
     try {
       const plugin = await extismContext.current.newPlugin(manifest);
-      const functions = await plugin.getExportedFunctions();
-      return functions;
+      const functions = await plugin.getExports();
+      return Object.keys(functions).filter(x => !x.startsWith("__") && x !== "memory")
     } catch (error) {
       console.log('ERROR IN LOAD', error);
     }


### PR DESCRIPTION
Everything should work the same. Just upgrading to the latest published version