### PR TITLE
feat: use tailwind forms plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@extism/runtime-browser": "0.0.1-rc.13",
+        "@tailwindcss/forms": "^0.5.3",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
@@ -3422,6 +3423,17 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/gregberge"
+      }
+    },
+    "node_modules/@tailwindcss/forms": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/forms/-/forms-0.5.3.tgz",
+      "integrity": "sha512-y5mb86JUoiUgBjY/o6FJSFZSEttfb3Q5gllE4xoKjAAD+vBrnIhE4dViwUuow3va8mpH4s9jyUbUbrRGoRdc2Q==",
+      "dependencies": {
+        "mini-svg-data-uri": "^1.2.3"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || >= 3.0.0-alpha.1"
       }
     },
     "node_modules/@testing-library/dom": {
@@ -11917,6 +11929,14 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/mini-svg-data-uri": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/mini-svg-data-uri/-/mini-svg-data-uri-1.4.4.tgz",
+      "integrity": "sha512-r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg==",
+      "bin": {
+        "mini-svg-data-uri": "cli.js"
+      }
+    },
     "node_modules/minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -19507,6 +19527,14 @@
         "loader-utils": "^2.0.0"
       }
     },
+    "@tailwindcss/forms": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/forms/-/forms-0.5.3.tgz",
+      "integrity": "sha512-y5mb86JUoiUgBjY/o6FJSFZSEttfb3Q5gllE4xoKjAAD+vBrnIhE4dViwUuow3va8mpH4s9jyUbUbrRGoRdc2Q==",
+      "requires": {
+        "mini-svg-data-uri": "^1.2.3"
+      }
+    },
     "@testing-library/dom": {
       "version": "8.19.0",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.19.0.tgz",
@@ -25755,6 +25783,11 @@
           }
         }
       }
+    },
+    "mini-svg-data-uri": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/mini-svg-data-uri/-/mini-svg-data-uri-1.4.4.tgz",
+      "integrity": "sha512-r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg=="
     },
     "minimalistic-assert": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "license": "BSD-3-Clause",
   "dependencies": {
     "@extism/runtime-browser": "0.0.1-rc.13",
+    "@tailwindcss/forms": "^0.5.3",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -276,39 +276,35 @@ const App: React.FC = () => {
           <label className="w-[200px] text-sm  font-semibold md:text-base md:font-bold md:text-lg lg:w-[20%] xl:max-w-[175px] ">
             Load Module From:
           </label>
-          <form className=" text-sm md:flex basis-10/12 md:items-center md:gap-4 ">
-            <div className="sm:flex basis-1/12 gap-2">
-              <input
-                className=""
-                onChange={() => {
-                  dispatch({ type: 'UPLOAD_TYPE', payload: 'url' });
-                }}
-                value="url"
-                type="radio"
-                defaultChecked
-                name="uploadType"
-                id="use_url"
-              />
-              <label className="text-sm md:text-lg" htmlFor="use_url">
-                URL
-              </label>
-            </div>
-            <div className="flex basis-1/12 gap-2">
-              <input
-                className=""
-                value="module"
-                onChange={() => {
-                  dispatch({ type: 'UPLOAD_TYPE', payload: 'module' });
-                }}
-                type="radio"
-                name="uploadType"
-                id="use_module"
-              />
+          <form className="text-sm md:flex basis-10/12 md:items-center md:gap-2">
+            <input
+              className=""
+              onChange={() => {
+                dispatch({ type: 'UPLOAD_TYPE', payload: 'url' });
+              }}
+              value="url"
+              type="radio"
+              defaultChecked
+              name="uploadType"
+              id="use_url"
+            />
+            <label className="text-sm md:text-lg" htmlFor="use_url">
+              URL
+            </label>
+            <input
+              className=""
+              value="module"
+              onChange={() => {
+                dispatch({ type: 'UPLOAD_TYPE', payload: 'module' });
+              }}
+              type="radio"
+              name="uploadType"
+              id="use_module"
+            />
 
-              <label className="text-sm md:min-w-[5rem] md:text-lg" htmlFor="use_module">
-                Local File
-              </label>
-            </div>
+            <label className="text-sm md:min-w-[5rem] md:text-lg" htmlFor="use_module">
+              Local File
+            </label>
           </form>
         </div>
         {/* MODULE SWITCH CONTAINER */}
@@ -331,7 +327,7 @@ const App: React.FC = () => {
                 className=" text-left  text-sm text-mid-gray bg-background-lightest  rounded flex  p-3 font-semibold h-11 md:h-11 md:flex gap-1 items-center rounded "
                 htmlFor="func_name"
               >
-                Function Name: <span className="font-mono text-string-red font-medium">{state.func_name}</span>
+                Function Name:
               </label>
 
               <select
@@ -341,7 +337,7 @@ const App: React.FC = () => {
                 id="func_name"
                 value={state.func_name}
                 onChange={handleFunctionDropDownChange}
-                className=" pt-10  bg-fit bg-dark-blue  bg-no-repeat bg-center  bg-[url('/src/assets/chevron-right.png')] basis-1/12 h-11 w-8 rounded relative overflow-hidden appearance-none "
+                className=""
                 // className=" appearance-none bg-fit bg-no-repeat bg-center pt-6 w-6 h-8  bg-[url('/src/assets/chevron-right.png')] bg-dark-blue   "
                 // className=" pt-10  bg-fit bg-dark-blue min-w-1/6 basis-1/6 bg-no-repeat bg-center  bg-[url('/src/assets/chevron-right.png')] basis-1/12 h-11 w-8 rounded relative appearance-none "
               >
@@ -364,7 +360,7 @@ const App: React.FC = () => {
               <DropDownMenu
                 mimeType={state.inputMimeType}
                 selectName="inputMimeType"
-                title={'Input'}
+                title={'Input Type'}
                 options={mimeOptions}
                 onChange={(e: React.ChangeEvent) => {
                   const element = e.target as HTMLSelectElement;
@@ -396,7 +392,7 @@ const App: React.FC = () => {
               <DropDownMenu
                 mimeType={state.outputMimeType}
                 selectName="outputMimeType"
-                title="Output"
+                title="Output Type"
                 options={mimeOptions}
                 onChange={(e: React.ChangeEvent) => {
                   const element = e.target as HTMLSelectElement;

--- a/src/components/Buttons/DropDownMenu/DropDownMenu.tsx
+++ b/src/components/Buttons/DropDownMenu/DropDownMenu.tsx
@@ -20,14 +20,14 @@ const DropDownMenu: React.FC<DropDownMenuProps> = function ({ title, onChange, o
         className=" md:h-11 md:flex gap-1 items-center  text-left  text-sm text-mid-gray bg-background-lightest  rounded  p-3 font-semibold "
         htmlFor="func_name"
       >
-        {title}: <span className="font-mono font-medium text-string-red">{mimeType}</span>
+        {title}:
       </label>
       <select
         name={selectName}
         id="func_name"
         required
         // className="funcName border-solid border-black"
-        className=" pt-10  bg-fit bg-dark-blue  bg-no-repeat bg-center  bg-[url('/src/assets/chevron-right.png')] basis-1/12 h-11 w-8 rounded relative overflow-hidden appearance-none "
+        className=""
         value={mimeType}
         onChange={(e) => onChange(e)}
       >

--- a/src/components/URLInput/URLInput.tsx
+++ b/src/components/URLInput/URLInput.tsx
@@ -24,12 +24,12 @@ const URLInput: React.FC<URLInputProps> = ({ onChange, url, defaultUrl }) => {
     }
   };
   return (
-    <div className="flex flex-col    py-1  basis-full  sm:gap-2 sm:flex-row sm:items-center sm:basis-3/4 ">
+    <div className="flex flex-col py-1 basis-full sm:gap-2 sm:flex-row sm:items-center sm:basis-3/4 ">
       <b className=" py-1 pr-1 font-semibold text-sm md:font-bold md:text-lg lg:w-[20%]">Module URL:</b>
       <input
         onKeyDown={onInputKeydown}
         onBlur={onInputBlur}
-        className="text-mid-gray bg-background-lightest hover:border-primary-accent w-9/12  sm:h-10  md:h-11 md:w-9/12 lg:w-[80%] "
+        className="w-9/12 sm:h-10 md:h-11 md:w-9/12 lg:w-[80%]"
         // className=" text-mid-gray bg-background-lightest  hover:border-primary-accent w-10/12 p-2  text-sm  accent-black md:basis-10/12  md:h-11 md:p-3 md:text-lg  "
         type="url"
         pattern="https://.*"

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -134,5 +134,7 @@ module.exports = {
       },
     },
   },
-  plugins: [],
+  plugins: [
+    require('@tailwindcss/forms'),
+  ],
 };


### PR DESCRIPTION
This is a plugin from the tailwinds team that adds some base UX rules to all the form elements. You can still customize them but it ensures that they behave similarly to their browser counterparts. For example, you can now see the selects look like normal dropdowns (with the down arrow) and the size and locations doesn't move around when the value changes.

https://github.com/tailwindlabs/tailwindcss-forms

<img width="535" alt="Screen Shot 2022-11-22 at 3 52 49 PM" src="https://user-images.githubusercontent.com/185919/203429178-d727ac0f-5972-46e0-8f21-5581ca426842.png">

<img width="540" alt="Screen Shot 2022-11-22 at 3 52 55 PM" src="https://user-images.githubusercontent.com/185919/203429169-0ace46b9-9c37-4a52-8e4f-552fae6ba68c.png">
