### PR TITLE
feat: render html in iframe

### DIFF
--- a/src/components/PluginOutput/GetOutputComponent.tsx
+++ b/src/components/PluginOutput/GetOutputComponent.tsx
@@ -61,7 +61,7 @@ const HTMLOutput: React.FC<OutputComponentProps> = ({ bytes }) => {
           width="100%"
           height="100%"
           srcDoc={text}
-          referrerpolicy="no-referrer"
+          referrerPolicy="no-referrer"
           allow="fullscreen"
           sandbox="allow-script"
         ></iframe>

--- a/src/components/PluginOutput/GetOutputComponent.tsx
+++ b/src/components/PluginOutput/GetOutputComponent.tsx
@@ -63,7 +63,7 @@ const HTMLOutput: React.FC<OutputComponentProps> = ({ bytes }) => {
           srcDoc={text}
           referrerPolicy="no-referrer"
           allow="fullscreen"
-          sandbox="allow-script"
+          sandbox="allow-scripts"
         ></iframe>
     </div>
   );

--- a/src/components/PluginOutput/GetOutputComponent.tsx
+++ b/src/components/PluginOutput/GetOutputComponent.tsx
@@ -7,6 +7,7 @@ import Spinner from '../Spinner/Spinner';
 import { DispatchFunc } from '../../types';
 import TESTJSON from '../../assets/test.json';
 
+
 type OutputComponentProps = {
   bytes: Uint8Array;
   dispatch: DispatchFunc;
@@ -55,16 +56,12 @@ const HTMLOutput: React.FC<OutputComponentProps> = ({ bytes }) => {
 
   return (
     <div id="plugin-output-area" className="output-text-component">
-      <SyntaxHighlighter
-        className="bg-blue break-all p-2 overflow-scroll max-h-full whitespace-pre-wrap"
-        language="xml-doc"
-        wrapLongLines={true}
-        style={oneLight}
-        codeTagProps={{ style: { wordBreak: 'break-word' } }}
-        customStyle={{ margin: 0 }}
-      >
-        {text}
-      </SyntaxHighlighter>
+        <iframe
+          title="html-output"
+          width="100%"
+          height="100%"
+          srcDoc={text}
+        ></iframe>
     </div>
   );
 };

--- a/src/components/PluginOutput/GetOutputComponent.tsx
+++ b/src/components/PluginOutput/GetOutputComponent.tsx
@@ -61,6 +61,9 @@ const HTMLOutput: React.FC<OutputComponentProps> = ({ bytes }) => {
           width="100%"
           height="100%"
           srcDoc={text}
+          referrerpolicy="no-referrer"
+          allow="fullscreen"
+          sandbox="allow-script"
         ></iframe>
     </div>
   );


### PR DESCRIPTION
WIP: let me look into the security of this before we merge.

This is something we discussed but didn't get around to. This changes the `HTMLOutput` component to render the html and not just the text. It uses an iframe for sandboxing and it allows js or anything to be loaded.

A couple notes:

* Is this actually secure? I need to think about it for a bit. There may be some more attributes i need to set on the iframe.
* User can still view the source with the text/plain mimetype. Should we assume they want to see it rendered? Provide another mime type?



https://user-images.githubusercontent.com/185919/205683649-3ab20b11-7d8a-47e3-a6f5-4022b3c01d6d.mp4

