### PR TITLE
feat: upgrade to unviersal js sdk, bug fixes & qol

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@extism/runtime-browser": "^0.2.7",
+        "@extism/extism": "^1.0.0-rc4",
         "jsonpath": "^1.1.1",
         "jsonpath-plus": "^7.2.0",
         "react": "^18.2.0",
@@ -2036,11 +2036,6 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
-    "node_modules/@bjorn3/browser_wasi_shim": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/@bjorn3/browser_wasi_shim/-/browser_wasi_shim-0.2.7.tgz",
-      "integrity": "sha512-ONBGleCpaH5HC4MLLkUmLz69xA28HQIbvwsdA1WTMXvjyhOWXR7jVrC0DkYr/iRqmkNMBZtEVVZWm1L6ZAnJvw=="
-    },
     "node_modules/@csstools/normalize.css": {
       "version": "12.0.0",
       "resolved": "https://registry.npmjs.org/@csstools/normalize.css/-/normalize.css-12.0.0.tgz",
@@ -2396,13 +2391,10 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@extism/runtime-browser": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/@extism/runtime-browser/-/runtime-browser-0.2.7.tgz",
-      "integrity": "sha512-rnfsQoLTwbkMNYw88jGqSyqnYCFynBcuCebF6jtcJEyijhCQ4ErfCraeD5MPcn9FptTXlUaxP0WP6v66DTNRWA==",
-      "dependencies": {
-        "@bjorn3/browser_wasi_shim": "^0.2.7"
-      }
+    "node_modules/@extism/extism": {
+      "version": "1.0.0-rc4",
+      "resolved": "https://registry.npmjs.org/@extism/extism/-/extism-1.0.0-rc4.tgz",
+      "integrity": "sha512-uCAoy1yIzR8SNSQ+KkqykWF8locHh+dq5OJbb3WfWKR4btXaz/KoywQnHzsmITJmSu1hv4XHOYb8AmuPjRe2Hw=="
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.7",
@@ -20104,11 +20096,6 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
-    "@bjorn3/browser_wasi_shim": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/@bjorn3/browser_wasi_shim/-/browser_wasi_shim-0.2.7.tgz",
-      "integrity": "sha512-ONBGleCpaH5HC4MLLkUmLz69xA28HQIbvwsdA1WTMXvjyhOWXR7jVrC0DkYr/iRqmkNMBZtEVVZWm1L6ZAnJvw=="
-    },
     "@csstools/normalize.css": {
       "version": "12.0.0",
       "resolved": "https://registry.npmjs.org/@csstools/normalize.css/-/normalize.css-12.0.0.tgz",
@@ -20300,13 +20287,10 @@
         }
       }
     },
-    "@extism/runtime-browser": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/@extism/runtime-browser/-/runtime-browser-0.2.7.tgz",
-      "integrity": "sha512-rnfsQoLTwbkMNYw88jGqSyqnYCFynBcuCebF6jtcJEyijhCQ4ErfCraeD5MPcn9FptTXlUaxP0WP6v66DTNRWA==",
-      "requires": {
-        "@bjorn3/browser_wasi_shim": "^0.2.7"
-      }
+    "@extism/extism": {
+      "version": "1.0.0-rc4",
+      "resolved": "https://registry.npmjs.org/@extism/extism/-/extism-1.0.0-rc4.tgz",
+      "integrity": "sha512-uCAoy1yIzR8SNSQ+KkqykWF8locHh+dq5OJbb3WfWKR4btXaz/KoywQnHzsmITJmSu1hv4XHOYb8AmuPjRe2Hw=="
     },
     "@humanwhocodes/config-array": {
       "version": "0.11.7",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     ]
   },
   "dependencies": {
-    "@extism/runtime-browser": "^0.2.7",
+    "@extism/extism": "^1.0.0-rc4",
     "jsonpath": "^1.1.1",
     "jsonpath-plus": "^7.2.0",
     "react": "^18.2.0",
@@ -38,20 +38,20 @@
     "web-vitals": "^2.1.4"
   },
   "devDependencies": {
-    "@types/jsonpath": "^0.2.0",
-    "@types/react-syntax-highlighter": "^15.5.5",
-    "autoprefixer": "^10.4.13",
-    "postcss": "^8.4.18",
-    "tailwindcss": "^3.2.3",
     "@tailwindcss/forms": "^0.5.3",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
     "@types/jest": "^27.5.2",
+    "@types/jsonpath": "^0.2.0",
     "@types/node": "^16.18.3",
     "@types/react": "^18.0.25",
     "@types/react-dom": "^18.0.8",
-    "typescript": "^4.8.4",
-    "react-scripts": "5.0.1"
+    "@types/react-syntax-highlighter": "^15.5.5",
+    "autoprefixer": "^10.4.13",
+    "postcss": "^8.4.18",
+    "react-scripts": "5.0.1",
+    "tailwindcss": "^3.2.3",
+    "typescript": "^4.8.4"
   }
 }

--- a/src/components/Drop-Down/SelectFunctionDropDown.tsx
+++ b/src/components/Drop-Down/SelectFunctionDropDown.tsx
@@ -3,17 +3,17 @@ import React from 'react';
 interface SelectFunctionDropDownProps {
   handleFunctionDropDownChange: React.ChangeEventHandler<HTMLSelectElement>;
   func_name: string;
-  functions: string[];
+  functions: WebAssembly.ModuleExportDescriptor[];
 }
 const SelectFunctionDropDown: React.FC<SelectFunctionDropDownProps> = ({
   handleFunctionDropDownChange,
   func_name,
   functions,
 }) => {
-  const funcOptions = functions.map((f: string, i: number) => {
+  const funcOptions = functions.map((f: WebAssembly.ModuleExportDescriptor, i: number) => {
     return (
-      <option key={i} value={f}>
-        {f}
+      <option key={i} value={f.name}>
+        {f.name}
       </option>
     );
   });

--- a/src/components/PluginOutput/GetOutputComponent.tsx
+++ b/src/components/PluginOutput/GetOutputComponent.tsx
@@ -42,7 +42,13 @@ const LoadingScreen: React.FC<OutputComponentProps> = () => {
 };
 
 const PlainText: React.FC<OutputComponentProps> = ({ bytes }) => {
-  const text = new TextDecoder().decode(bytes);
+  let text: string;
+  try {
+    text = new TextDecoder().decode(bytes);
+  } catch (e) {
+    text = e as string;
+    console.error(e)
+  }
 
   return (
     <textarea className="output-text-component rounded p-2" id="plugin-output-area" name="output" disabled value={text}>
@@ -56,15 +62,15 @@ const HTMLOutput: React.FC<OutputComponentProps> = ({ bytes }) => {
 
   return (
     <div id="plugin-output-area" className="output-text-component">
-        <iframe
-          title="html-output"
-          width="100%"
-          height="100%"
-          srcDoc={text}
-          referrerPolicy="no-referrer"
-          allow="fullscreen"
-          sandbox="allow-scripts"
-        ></iframe>
+      <iframe
+        title="html-output"
+        width="100%"
+        height="100%"
+        srcDoc={text}
+        referrerPolicy="no-referrer"
+        allow="fullscreen"
+        sandbox="allow-scripts"
+      ></iframe>
     </div>
   );
 };


### PR DESCRIPTION
- revert to using a count_vowels wasm plugin created when the namespace was just `env`
- upgrade to @extism/extism@1.0.0-rc4 (universal js sdk)
- better error handling & file/path manifest